### PR TITLE
Improve FFmpeg handling and error reporting

### DIFF
--- a/app.py
+++ b/app.py
@@ -147,7 +147,10 @@ def _handle_generation(tmp_dir: Path) -> Optional[DeckBuildResult]:
         st.error("Speaker WAV tidak ditemukan (upload atau letakkan 'vocal_serena1.wav' di root proyek).")
         return None
 
-    ffmpeg_path = Path(ffmpeg_path_text).expanduser() if ffmpeg_path_text else None
+    ffmpeg_text = ffmpeg_path_text.strip()
+    if ffmpeg_text.startswith('"') and ffmpeg_text.endswith('"'):
+        ffmpeg_text = ffmpeg_text[1:-1]
+    ffmpeg_path = Path(ffmpeg_text).expanduser() if ffmpeg_text else None
     out_dir = Path(output_dir_text).expanduser()
 
     with st.status("Menyiapkan…", expanded=True) as status:


### PR DESCRIPTION
## Summary
- validate and normalise the FFmpeg path, configuring pydub with the resolved binary and clearer export errors
- surface a more descriptive FileNotFoundError when FFmpeg cannot be executed during audio export
- trim surrounding quotes from the FFmpeg path supplied in the Streamlit UI for better Windows compatibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5608a1488832ca04db66d08083091