### PR TITLE
Add Hanzi audio helper tab and reusable audio engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [2.0.0] - 2024-05-12
+### Added
+- Streamlit UI now features separate tabs for the deck builder and a new "Hanzi → Audio" helper.
+- Quick audio helper synthesises Hanzi text to MP3/WAV using the existing TTS pipeline with in-app preview and download.
+- Exposed reusable `generate_audio_from_text` helper via `mandarin_anki.audio_engine` for standalone audio generation.
+
+### Changed
+- Sidebar now includes an editable FFmpeg path field.
+- Documentation updated to highlight version 2.0 capabilities.
+
+[2.0.0]: https://github.com/<username>/mandarin-anki-ui/releases/tag/v2.0.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mandarin → Anki Deck Builder
+# Mandarin → Anki Deck Builder (v2.0)
 
 A Streamlit web app that turns Mandarin vocabulary or sentence lists into polished Anki decks complete with Coqui TTS audio.
 
@@ -9,6 +9,7 @@ A Streamlit web app that turns Mandarin vocabulary or sentence lists into polish
 - Pengaturan delimiter, encoding, pemetaan kolom, dan bitrate audio.
 - Progress bar & log status saat build deck.
 - Galat per baris ditampilkan sehingga mudah diperbaiki.
+- Tab "🔊 Hanzi → Audio" untuk membuat audio MP3/WAV cepat dari teks Hanzi dan mengunduhnya langsung.
 
 ## 🚀 Persiapan di Windows
 
@@ -36,6 +37,8 @@ A Streamlit web app that turns Mandarin vocabulary or sentence lists into polish
    streamlit run app.py
    ```
 7. Buka browser ke `http://localhost:8501`.
+
+Tab pertama berfokus pada builder deck CSV → `.apkg`, sedangkan tab kedua memungkinkan Anda mengetik Hanzi lalu langsung memutar atau mengunduh hasil audionya.
 
 ## 🛠️ Troubleshooting
 

--- a/mandarin_anki/__init__.py
+++ b/mandarin_anki/__init__.py
@@ -7,6 +7,9 @@ from .builder import (
     ProgressCallback,
     build_anki_deck,
 )
+from .audio_engine import AudioGenerationConfig, generate_audio_from_text
+
+__version__ = "2.0.0"
 
 __all__ = [
     "DeckBuildConfig",
@@ -15,4 +18,7 @@ __all__ = [
     "ProgressEvent",
     "ProgressCallback",
     "build_anki_deck",
+    "AudioGenerationConfig",
+    "generate_audio_from_text",
+    "__version__",
 ]

--- a/mandarin_anki/audio_engine.py
+++ b/mandarin_anki/audio_engine.py
@@ -1,0 +1,124 @@
+"""Reusable helpers for synthesising Mandarin audio clips."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence
+
+from .builder import (
+    DeckBuildError,
+    DefaultTTSFactory,
+    TTSFactory,
+    TTSLike,
+    _ensure_ffmpeg,
+    _render_audio,
+)
+
+
+@dataclass(frozen=True)
+class AudioGenerationConfig:
+    """Configuration options for :func:`generate_audio_from_text`."""
+
+    text: str
+    output_path: Path
+    speaker_wav: Path
+    tts_model_name: str
+    tts_lang: str
+    ffmpeg_path: Optional[Path] = None
+    ambient_wav: Optional[Path] = None
+    volume_voice_db: float = -6.0
+    volume_ambient_db: float = -38.0
+    bitrate: str = "192k"
+    audio_format: str = "mp3"
+    device_preference: Sequence[str] = ("cuda", "cpu")
+
+
+class _AudioConfigProxy:
+    """Minimal view over deck config attributes consumed by ``_render_audio``."""
+
+    def __init__(
+        self,
+        *,
+        tts_lang: str,
+        volume_voice_db: float,
+        volume_ambient_db: float,
+        bitrate: str,
+        audio_format: str,
+    ) -> None:
+        self.tts_lang = tts_lang
+        self.volume_voice_db = volume_voice_db
+        self.volume_ambient_db = volume_ambient_db
+        self.bitrate = bitrate
+        self.audio_format = audio_format
+
+
+def _prepare_tts(
+    *,
+    factory: TTSFactory,
+    model_name: str,
+    device_preference: Sequence[str],
+) -> TTSLike:
+    tts = factory.create(model_name)
+    for device in device_preference:
+        try:
+            tts.to(device)
+            break
+        except Exception:
+            continue
+    return tts
+
+
+def generate_audio_from_text(
+    config: AudioGenerationConfig,
+    *,
+    tts_factory: Optional[TTSFactory] = None,
+) -> Path:
+    """Generate an audio clip for arbitrary Hanzi text and return the file path."""
+
+    text = (config.text or "").strip()
+    if not text:
+        raise DeckBuildError("Teks Hanzi tidak boleh kosong.")
+
+    speaker = config.speaker_wav.expanduser()
+    if not speaker.exists():
+        raise DeckBuildError(f"Speaker WAV tidak ditemukan: {speaker}")
+
+    ambient = config.ambient_wav.expanduser() if config.ambient_wav else None
+    if ambient is not None and not ambient.exists():
+        ambient = None
+
+    output_path = config.output_path.expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    _ensure_ffmpeg(config.ffmpeg_path)
+
+    factory = tts_factory or DefaultTTSFactory()
+    tts = _prepare_tts(
+        factory=factory,
+        model_name=config.tts_model_name,
+        device_preference=config.device_preference,
+    )
+
+    tmp_wav = output_path.with_name(f"{output_path.stem}_tmp.wav")
+    proxy = _AudioConfigProxy(
+        tts_lang=config.tts_lang,
+        volume_voice_db=config.volume_voice_db,
+        volume_ambient_db=config.volume_ambient_db,
+        bitrate=config.bitrate,
+        audio_format=config.audio_format,
+    )
+
+    _render_audio(
+        tts=tts,
+        text=text,
+        tmp_wav=tmp_wav,
+        speaker_wav=speaker,
+        ambient_wav=ambient,
+        config=proxy,
+        final_path=output_path,
+    )
+
+    return output_path
+
+
+__all__ = ["AudioGenerationConfig", "generate_audio_from_text"]


### PR DESCRIPTION
## Summary
- add a reusable audio engine helper and expose it via the package API
- split the Streamlit UI into deck builder and Hanzi → audio tabs with preview/download support
- document the v2.0 release, including changelog and updated README details

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d61e709614832cb714893ff7cca63c