### PR TITLE
Add optional speaker upload for Hanzi audio helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Streamlit web app that turns Mandarin vocabulary or sentence lists into polish
 - Progress bar & log status saat build deck.
 - Galat per baris ditampilkan sehingga mudah diperbaiki.
 - Tab "🔊 Hanzi → Audio" untuk membuat audio MP3/WAV cepat dari teks Hanzi dan mengunduhnya langsung.
+- Dukungan upload opsional file speaker WAV di tab Hanzi → Audio (gunakan `vocal_serena1.wav` bawaan jika tidak memilih file).
 
 ## 🚀 Persiapan di Windows
 

--- a/app.py
+++ b/app.py
@@ -44,6 +44,9 @@ project_root = Path(".").resolve()
 default_speaker = project_root / "vocal_serena1.wav"
 default_ambient = project_root / "room.wav"
 
+# Placeholder to satisfy type checkers; actual value diberikan oleh uploader Streamlit di tab deck.
+deck_speaker_file = None
+
 def _resolve_default_audio(label: str, default_path: Path) -> None:
     if not default_path.exists():
         st.sidebar.warning(f"Letakkan file default {label} di: {default_path}")
@@ -88,7 +91,7 @@ def _handle_generation(tmp_dir: Path) -> Optional[DeckBuildResult]:
     csv_path = tmp_dir / "input.csv"
     csv_path.write_bytes(csv_file.read())
 
-    speaker_path = _prepare_audio_file(speaker_file, tmp_dir, "speaker.wav", default_speaker)
+    speaker_path = _prepare_audio_file(deck_speaker_file, tmp_dir, "speaker.wav", default_speaker)
     ambient_path = None
     if ambient_file:
         ambient_path = _prepare_audio_file(ambient_file, tmp_dir, "ambient.wav", default_ambient)
@@ -200,7 +203,9 @@ with deck_tab:
     with left:
         st.subheader("📥 Upload")
         csv_file = st.file_uploader("CSV (delimiter sesuai pilihan)", type=["csv", "txt"], key="csv_uploader")
-        speaker_file = st.file_uploader("Speaker WAV (opsional)", type=["wav"], key="speaker_uploader")
+        deck_speaker_file = st.file_uploader(
+            "Speaker WAV (opsional)", type=["wav"], key="speaker_uploader"
+        )
         ambient_file = st.file_uploader("Ambient WAV (opsional)", type=["wav"], key="ambient_uploader")
 
         st.markdown(
@@ -249,6 +254,17 @@ with audio_tab:
 
     hanzi_text = st.text_area("Teks Hanzi", height=220, placeholder="例如：今天的天气怎么样？")
 
+    audio_speaker_file = st.file_uploader(
+        "Speaker WAV khusus tab ini (opsional)",
+        type=["wav"],
+        key="audio_tab_speaker_uploader",
+    )
+    st.markdown(
+        "<span class='small'>Opsional: unggah sampel suara .wav untuk meniru speaker tertentu."
+        " Jika dikosongkan, aplikasi memakai `vocal_serena1.wav` bawaan.</span>",
+        unsafe_allow_html=True,
+    )
+
     preview_state = st.session_state.setdefault("audio_preview", {})
 
     if st.button("🎧 Generate Audio", type="primary", key="generate_audio_button"):
@@ -257,7 +273,9 @@ with audio_tab:
         else:
             with tempfile.TemporaryDirectory() as tmpdir:
                 tmp_dir = Path(tmpdir)
-                speaker_path = _prepare_audio_file(speaker_file, tmp_dir, "speaker.wav", default_speaker)
+                speaker_path = _prepare_audio_file(
+                    audio_speaker_file, tmp_dir, "speaker.wav", default_speaker
+                )
                 ambient_path = None
                 if ambient_file:
                     ambient_path = _prepare_audio_file(ambient_file, tmp_dir, "ambient.wav", default_ambient)


### PR DESCRIPTION
## Summary
- add a dedicated optional speaker WAV uploader to the Hanzi → Audio tab that falls back to the default voice sample
- update deck builder logic to use its own speaker upload binding while preserving default fallbacks
- document the optional speaker selection in the README so users know they can override the default voice

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6ab59c6f8832cbb9bbc9a0978120e